### PR TITLE
Update requirements and fix paths to run v6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is currently a Beta version and therefore subject to future changes.
 
 Running this service locally will require the following :
 * Python 3
+* Python 3 header files and a static library for Python (`python3-dev` on Debian/ Ubuntu)
 
 To start the service, run the run.sh file in Terminal (i.e. ./run.sh).
 If using Windows, run the run_in_windows.bat file in a cmd window. 

--- a/local_land_charges_api_stub/schema/v6_0/semantics.py
+++ b/local_land_charges_api_stub/schema/v6_0/semantics.py
@@ -1,4 +1,4 @@
-from validation_api.app import app
+from local_land_charges_api_stub.app import app
 
 
 def validate_geometry_ids(item):

--- a/local_land_charges_api_stub/validation/schema_extension.py
+++ b/local_land_charges_api_stub/validation/schema_extension.py
@@ -5,7 +5,7 @@ from importlib import import_module
 
 SCHEMA_RELATIVE_DIRECTORY = "schema"
 SCHEMA_FILENAME = "local-land-charge.json"
-SCHEMA_VERSIONS = ["v2_0", "v3_0", "v4_0", "v5_0", "V6_0"]
+SCHEMA_VERSIONS = ["v2_0", "v3_0", "v4_0", "v5_0", "v6_0"]
 
 
 class SchemaExtension(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-Negotiate==0.1.0
 Flask-Script==2.0.5
 requests==2.13
 jsonschema==2.6.0
+wheel==0.32.3


### PR DESCRIPTION
I had a few issues running the API locally on Ubuntu 16.04 and with v6.0 of the schema. This PR includes the fairly minor changes I made.